### PR TITLE
feat(android): add Wear OS support via Data Layer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,8 +509,12 @@ struct StatusView: View {
 <docgen-api>
 <!--Update the source file JSDoc comments and rerun docgen to update the docs below-->
 
-Apple Watch communication plugin for Capacitor.
-Provides bidirectional messaging between iPhone and Apple Watch using WatchConnectivity.
+Watch / Wear OS communication plugin for Capacitor.
+Provides bidirectional messaging between the phone and a paired watch.
+
+- **iOS**: uses Apple WatchConnectivity framework to communicate with Apple Watch.
+- **Android**: uses Google Wear OS Data Layer API (play-services-wearable) to communicate with a Wear OS watch.
+- **Web**: not supported; all methods throw or return safe defaults.
 
 ### sendMessage(...)
 
@@ -792,15 +796,15 @@ Options for replying to a message from the watch.
 
 #### WatchInfo
 
-Information about Watch connectivity status.
+Information about Watch / Wear OS connectivity status.
 
-| Prop                      | Type                 | Description                                                                                    |
-| ------------------------- | -------------------- | ---------------------------------------------------------------------------------------------- |
-| **`isSupported`**         | <code>boolean</code> | Whether WatchConnectivity is supported on this device. Always false on iPad, web, and Android. |
-| **`isPaired`**            | <code>boolean</code> | Whether an Apple Watch is paired with this iPhone.                                             |
-| **`isWatchAppInstalled`** | <code>boolean</code> | Whether the paired watch has the companion app installed.                                      |
-| **`isReachable`**         | <code>boolean</code> | Whether the watch is currently reachable for immediate messaging.                              |
-| **`activationState`**     | <code>number</code>  | The current activation state of the WCSession. 0 = notActivated, 1 = inactive, 2 = activated   |
+| Prop                      | Type                 | Description                                                                                                                                                                                                                                                   |
+| ------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`isSupported`**         | <code>boolean</code> | Whether the watch communication API is supported on this device. - iOS: false on iPad; true on iPhone when WatchConnectivity is available. - Android: true when Google Play Services with Wear OS support is available; false otherwise. - Web: always false. |
+| **`isPaired`**            | <code>boolean</code> | Whether a watch is currently paired/connected. - iOS: whether an Apple Watch is paired with this iPhone. - Android: whether at least one Wear OS node is currently connected.                                                                                 |
+| **`isWatchAppInstalled`** | <code>boolean</code> | Whether the watch companion app is installed. - iOS: whether the paired Apple Watch has the companion app installed. - Android: whether at least one connected Wear OS node is reachable (used as a proxy).                                                   |
+| **`isReachable`**         | <code>boolean</code> | Whether the watch is currently reachable for immediate messaging.                                                                                                                                                                                             |
+| **`activationState`**     | <code>number</code>  | The current session activation state. - iOS: 0 = notActivated, 1 = inactive, 2 = activated (WCSessionActivationState). - Android: 2 when a Wear OS node is connected, 0 otherwise.                                                                            |
 
 
 #### PluginListenerHandle

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(':capacitor-android')
     implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation "com.google.android.gms:play-services-wearable:18.1.0"
     testImplementation "junit:junit:$junitVersion"
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"

--- a/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
@@ -1,5 +1,6 @@
 package app.capgo.capacitor.watch;
 
+import android.net.Uri;
 import android.util.Log;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -7,6 +8,8 @@ import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 import com.google.android.gms.tasks.Tasks;
+import com.google.android.gms.wearable.CapabilityClient;
+import com.google.android.gms.wearable.CapabilityInfo;
 import com.google.android.gms.wearable.DataClient;
 import com.google.android.gms.wearable.DataEvent;
 import com.google.android.gms.wearable.DataEventBuffer;
@@ -19,6 +22,7 @@ import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.Wearable;
 import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -49,6 +53,9 @@ public class CapgoWatchPlugin extends Plugin {
     private static final String TAG = "CapgoWatchPlugin";
     private static final String PLUGIN_VERSION = "8.0.25";
 
+    /** Capability advertised by the companion Wear OS app. */
+    static final String WATCH_APP_CAPABILITY = "capgo_watch";
+
     /** Path for regular messages sent/received via MessageClient. */
     static final String PATH_MESSAGE = "/capgo/message";
     /** Path prefix for messages that require a reply. */
@@ -60,8 +67,11 @@ public class CapgoWatchPlugin extends Plugin {
     /** DataItem path prefix for user info transfers. */
     static final String PATH_USER_INFO = "/capgo/userinfo/";
 
-    /** Maps callbackId to sourceNodeId for pending reply messages. */
-    private final Map<String, String> pendingReplies = new ConcurrentHashMap<>();
+    /** Pending reply callbacks expire after 5 minutes. */
+    private static final long PENDING_REPLY_TTL_MS = 5 * 60 * 1000L;
+
+    /** Maps callbackId to pending reply metadata. */
+    private final Map<String, PendingReply> pendingReplies = new ConcurrentHashMap<>();
 
     /** Shared thread pool for all background Wear OS operations. */
     private final ExecutorService executor = Executors.newCachedThreadPool();
@@ -72,12 +82,23 @@ public class CapgoWatchPlugin extends Plugin {
     private final MessageClient.OnMessageReceivedListener messageListener = this::handleMessageReceived;
     private final DataClient.OnDataChangedListener dataListener = this::handleDataChanged;
 
+    private static final class PendingReply {
+
+        final String nodeId;
+        final long createdAt;
+
+        PendingReply(final String nodeId, final long createdAt) {
+            this.nodeId = nodeId;
+            this.createdAt = createdAt;
+        }
+    }
+
     @Override
     public void load() {
         messageClient = Wearable.getMessageClient(getContext());
         dataClient = Wearable.getDataClient(getContext());
-        messageClient.addListener(messageListener);
-        dataClient.addListener(dataListener);
+        messageClient.addListener(messageListener).addOnFailureListener((e) -> Log.e(TAG, "Failed to register message listener", e));
+        dataClient.addListener(dataListener).addOnFailureListener((e) -> Log.e(TAG, "Failed to register data listener", e));
     }
 
     @Override
@@ -91,10 +112,27 @@ public class CapgoWatchPlugin extends Plugin {
         executor.shutdown();
     }
 
+    private void expirePendingReplies() {
+        final long now = System.currentTimeMillis();
+        final Iterator<Map.Entry<String, PendingReply>> iterator = pendingReplies.entrySet().iterator();
+        while (iterator.hasNext()) {
+            final Map.Entry<String, PendingReply> entry = iterator.next();
+            if (now - entry.getValue().createdAt > PENDING_REPLY_TTL_MS) {
+                iterator.remove();
+            }
+        }
+    }
+
     // ── Incoming message / data handlers ─────────────────────────────────────
 
     private void handleMessageReceived(MessageEvent event) {
         final String path = event.getPath();
+        if (!PATH_MESSAGE.equals(path) && !PATH_MESSAGE_WITH_REPLY.equals(path)) {
+            return;
+        }
+
+        expirePendingReplies();
+
         final String nodeId = event.getSourceNodeId();
         final String payload = new String(event.getData(), StandardCharsets.UTF_8);
 
@@ -102,9 +140,9 @@ public class CapgoWatchPlugin extends Plugin {
             final JSONObject json = new JSONObject(payload);
             final JSObject messageData = new JSObject(json.toString());
 
-            if (path != null && path.startsWith(PATH_MESSAGE_WITH_REPLY)) {
+            if (PATH_MESSAGE_WITH_REPLY.equals(path)) {
                 final String callbackId = UUID.randomUUID().toString();
-                pendingReplies.put(callbackId, nodeId);
+                pendingReplies.put(callbackId, new PendingReply(nodeId, System.currentTimeMillis()));
 
                 final JSObject evt = new JSObject();
                 evt.put("message", messageData);
@@ -122,29 +160,49 @@ public class CapgoWatchPlugin extends Plugin {
 
     private void handleDataChanged(DataEventBuffer dataEvents) {
         for (DataEvent event : dataEvents) {
-            if (event.getType() == DataEvent.TYPE_CHANGED) {
-                final DataItem item = event.getDataItem();
-                final String path = item.getUri().getPath();
-                try {
-                    final DataMap dataMap = DataMapItem.fromDataItem(item).getDataMap();
-                    final String payload = dataMap.getString("payload", "{}");
-                    final JSONObject json = new JSONObject(payload);
-                    final JSObject data = new JSObject(json.toString());
+            if (event.getType() != DataEvent.TYPE_CHANGED) {
+                continue;
+            }
 
-                    if (path != null && path.startsWith(PATH_CONTEXT)) {
-                        final JSObject evt = new JSObject();
-                        evt.put("context", data);
-                        notifyListeners("applicationContextReceived", evt);
-                    } else if (path != null && path.startsWith(PATH_USER_INFO)) {
-                        final JSObject evt = new JSObject();
-                        evt.put("userInfo", data);
-                        notifyListeners("userInfoReceived", evt);
-                    }
-                } catch (Exception e) {
-                    Log.e(TAG, "Error processing data change", e);
+            final DataItem item = event.getDataItem();
+            final String path = item.getUri().getPath();
+            if (path == null) {
+                continue;
+            }
+
+            final boolean isContext = PATH_CONTEXT.equals(path);
+            final boolean isUserInfo = path.startsWith(PATH_USER_INFO);
+            if (!isContext && !isUserInfo) {
+                continue;
+            }
+
+            try {
+                final DataMap dataMap = DataMapItem.fromDataItem(item).getDataMap();
+                final String payload = dataMap.getString("payload", "{}");
+                final JSONObject json = new JSONObject(payload);
+                final JSObject data = new JSObject(json.toString());
+
+                if (isContext) {
+                    final JSObject evt = new JSObject();
+                    evt.put("context", data);
+                    notifyListeners("applicationContextReceived", evt);
+                } else {
+                    final JSObject evt = new JSObject();
+                    evt.put("userInfo", data);
+                    notifyListeners("userInfoReceived", evt);
+                    deleteDataItem(item.getUri());
                 }
+            } catch (Exception e) {
+                Log.e(TAG, "Error processing data change", e);
             }
         }
+    }
+
+    private void deleteDataItem(final Uri uri) {
+        if (dataClient == null) {
+            return;
+        }
+        dataClient.deleteDataItems(uri).addOnFailureListener((e) -> Log.w(TAG, "Failed to delete delivered user info DataItem", e));
     }
 
     // ── Plugin methods ────────────────────────────────────────────────────────
@@ -232,17 +290,26 @@ public class CapgoWatchPlugin extends Plugin {
             return;
         }
 
-        final String nodeId = pendingReplies.remove(callbackId);
-        if (nodeId == null) {
+        expirePendingReplies();
+
+        final PendingReply pendingReply = pendingReplies.get(callbackId);
+        if (pendingReply == null) {
             call.reject("No pending reply found for callbackId: " + callbackId);
             return;
         }
+        if (System.currentTimeMillis() - pendingReply.createdAt > PENDING_REPLY_TTL_MS) {
+            pendingReplies.remove(callbackId);
+            call.reject("Pending reply expired for callbackId: " + callbackId);
+            return;
+        }
 
+        final String nodeId = pendingReply.nodeId;
         final byte[] payload = data.toString().getBytes(StandardCharsets.UTF_8);
         final String replyPath = PATH_REPLY + callbackId;
         executor.execute(() -> {
             try {
                 Tasks.await(messageClient.sendMessage(nodeId, replyPath, payload));
+                pendingReplies.remove(callbackId);
                 call.resolve();
             } catch (ExecutionException | InterruptedException e) {
                 call.reject("Failed to send reply: " + e.getMessage(), e);
@@ -256,10 +323,15 @@ public class CapgoWatchPlugin extends Plugin {
             try {
                 final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
                 final boolean isReachable = !nodes.isEmpty();
+                final CapabilityClient capabilityClient = Wearable.getCapabilityClient(getContext());
+                final CapabilityInfo capabilityInfo = Tasks.await(
+                    capabilityClient.getCapability(WATCH_APP_CAPABILITY, CapabilityClient.FILTER_ALL)
+                );
+                final boolean isWatchAppInstalled = !capabilityInfo.getNodes().isEmpty();
                 final JSObject ret = new JSObject();
                 ret.put("isSupported", true);
                 ret.put("isPaired", isReachable);
-                ret.put("isWatchAppInstalled", isReachable);
+                ret.put("isWatchAppInstalled", isWatchAppInstalled);
                 ret.put("isReachable", isReachable);
                 ret.put("activationState", isReachable ? 2 : 0);
                 call.resolve(ret);

--- a/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
@@ -1,13 +1,11 @@
 package app.capgo.capacitor.watch;
 
 import android.util.Log;
-
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
-
 import com.google.android.gms.tasks.Tasks;
 import com.google.android.gms.wearable.DataClient;
 import com.google.android.gms.wearable.DataEvent;
@@ -20,10 +18,6 @@ import com.google.android.gms.wearable.MessageEvent;
 import com.google.android.gms.wearable.Node;
 import com.google.android.gms.wearable.PutDataMapRequest;
 import com.google.android.gms.wearable.Wearable;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +26,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 /**
  * Wear OS communication plugin for Capacitor.
@@ -162,23 +158,21 @@ public class CapgoWatchPlugin extends Plugin {
         }
 
         final byte[] payload = data.toString().getBytes(StandardCharsets.UTF_8);
-        executor.execute(
-            () -> {
-                try {
-                    final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
-                    if (nodes.isEmpty()) {
-                        call.reject("No connected Wear OS devices found");
-                        return;
-                    }
-                    for (final Node node : nodes) {
-                        Tasks.await(messageClient.sendMessage(node.getId(), PATH_MESSAGE, payload));
-                    }
-                    call.resolve();
-                } catch (ExecutionException | InterruptedException e) {
-                    call.reject("Failed to send message: " + e.getMessage(), e);
+        executor.execute(() -> {
+            try {
+                final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
+                if (nodes.isEmpty()) {
+                    call.reject("No connected Wear OS devices found");
+                    return;
                 }
+                for (final Node node : nodes) {
+                    Tasks.await(messageClient.sendMessage(node.getId(), PATH_MESSAGE, payload));
+                }
+                call.resolve();
+            } catch (ExecutionException | InterruptedException e) {
+                call.reject("Failed to send message: " + e.getMessage(), e);
             }
-        );
+        });
     }
 
     @PluginMethod
@@ -189,19 +183,17 @@ public class CapgoWatchPlugin extends Plugin {
             return;
         }
 
-        executor.execute(
-            () -> {
-                try {
-                    final PutDataMapRequest request = PutDataMapRequest.create(PATH_CONTEXT);
-                    request.getDataMap().putString("payload", context.toString());
-                    request.setUrgent();
-                    Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
-                    call.resolve();
-                } catch (ExecutionException | InterruptedException e) {
-                    call.reject("Failed to update application context: " + e.getMessage(), e);
-                }
+        executor.execute(() -> {
+            try {
+                final PutDataMapRequest request = PutDataMapRequest.create(PATH_CONTEXT);
+                request.getDataMap().putString("payload", context.toString());
+                request.setUrgent();
+                Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
+                call.resolve();
+            } catch (ExecutionException | InterruptedException e) {
+                call.reject("Failed to update application context: " + e.getMessage(), e);
             }
-        );
+        });
     }
 
     @PluginMethod
@@ -213,19 +205,17 @@ public class CapgoWatchPlugin extends Plugin {
         }
 
         final String path = PATH_USER_INFO + UUID.randomUUID();
-        executor.execute(
-            () -> {
-                try {
-                    final PutDataMapRequest request = PutDataMapRequest.create(path);
-                    request.getDataMap().putString("payload", userInfo.toString());
-                    request.setUrgent();
-                    Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
-                    call.resolve();
-                } catch (ExecutionException | InterruptedException e) {
-                    call.reject("Failed to transfer user info: " + e.getMessage(), e);
-                }
+        executor.execute(() -> {
+            try {
+                final PutDataMapRequest request = PutDataMapRequest.create(path);
+                request.getDataMap().putString("payload", userInfo.toString());
+                request.setUrgent();
+                Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
+                call.resolve();
+            } catch (ExecutionException | InterruptedException e) {
+                call.reject("Failed to transfer user info: " + e.getMessage(), e);
             }
-        );
+        });
     }
 
     @PluginMethod
@@ -250,44 +240,40 @@ public class CapgoWatchPlugin extends Plugin {
 
         final byte[] payload = data.toString().getBytes(StandardCharsets.UTF_8);
         final String replyPath = PATH_REPLY + callbackId;
-        executor.execute(
-            () -> {
-                try {
-                    Tasks.await(messageClient.sendMessage(nodeId, replyPath, payload));
-                    call.resolve();
-                } catch (ExecutionException | InterruptedException e) {
-                    call.reject("Failed to send reply: " + e.getMessage(), e);
-                }
+        executor.execute(() -> {
+            try {
+                Tasks.await(messageClient.sendMessage(nodeId, replyPath, payload));
+                call.resolve();
+            } catch (ExecutionException | InterruptedException e) {
+                call.reject("Failed to send reply: " + e.getMessage(), e);
             }
-        );
+        });
     }
 
     @PluginMethod
     public void getInfo(final PluginCall call) {
-        executor.execute(
-            () -> {
-                try {
-                    final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
-                    final boolean isReachable = !nodes.isEmpty();
-                    final JSObject ret = new JSObject();
-                    ret.put("isSupported", true);
-                    ret.put("isPaired", isReachable);
-                    ret.put("isWatchAppInstalled", isReachable);
-                    ret.put("isReachable", isReachable);
-                    ret.put("activationState", isReachable ? 2 : 0);
-                    call.resolve(ret);
-                } catch (ExecutionException | InterruptedException e) {
-                    // Wear OS API unavailable (e.g. Google Play Services missing)
-                    final JSObject ret = new JSObject();
-                    ret.put("isSupported", false);
-                    ret.put("isPaired", false);
-                    ret.put("isWatchAppInstalled", false);
-                    ret.put("isReachable", false);
-                    ret.put("activationState", 0);
-                    call.resolve(ret);
-                }
+        executor.execute(() -> {
+            try {
+                final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
+                final boolean isReachable = !nodes.isEmpty();
+                final JSObject ret = new JSObject();
+                ret.put("isSupported", true);
+                ret.put("isPaired", isReachable);
+                ret.put("isWatchAppInstalled", isReachable);
+                ret.put("isReachable", isReachable);
+                ret.put("activationState", isReachable ? 2 : 0);
+                call.resolve(ret);
+            } catch (ExecutionException | InterruptedException e) {
+                // Wear OS API unavailable (e.g. Google Play Services missing)
+                final JSObject ret = new JSObject();
+                ret.put("isSupported", false);
+                ret.put("isPaired", false);
+                ret.put("isWatchAppInstalled", false);
+                ret.put("isReachable", false);
+                ret.put("activationState", 0);
+                call.resolve(ret);
             }
-        );
+        });
     }
 
     @PluginMethod

--- a/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
+++ b/android/src/main/java/app/capgo/capacitor/watch/CapgoWatchPlugin.java
@@ -1,61 +1,299 @@
 package app.capgo.capacitor.watch;
 
+import android.util.Log;
+
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
 
+import com.google.android.gms.tasks.Tasks;
+import com.google.android.gms.wearable.DataClient;
+import com.google.android.gms.wearable.DataEvent;
+import com.google.android.gms.wearable.DataEventBuffer;
+import com.google.android.gms.wearable.DataItem;
+import com.google.android.gms.wearable.DataMap;
+import com.google.android.gms.wearable.DataMapItem;
+import com.google.android.gms.wearable.MessageClient;
+import com.google.android.gms.wearable.MessageEvent;
+import com.google.android.gms.wearable.Node;
+import com.google.android.gms.wearable.PutDataMapRequest;
+import com.google.android.gms.wearable.Wearable;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 /**
- * Apple Watch communication plugin for Capacitor.
- * This plugin only works on iOS - Android implementation provides stub methods
- * that return appropriate error messages.
+ * Wear OS communication plugin for Capacitor.
+ * Provides bidirectional messaging between Android phone and Wear OS watch
+ * using the Wear OS Data Layer API (play-services-wearable).
+ *
+ * <p>Message paths used over the Data Layer:</p>
+ * <ul>
+ *   <li>{@code /capgo/message} — regular one-way messages</li>
+ *   <li>{@code /capgo/message/withreply} — messages that expect a reply</li>
+ *   <li>{@code /capgo/reply/{callbackId}} — reply to a watch-initiated message</li>
+ *   <li>{@code /capgo/context} — application context sync via DataItem</li>
+ *   <li>{@code /capgo/userinfo/{uuid}} — queued user-info transfer via DataItem</li>
+ * </ul>
  */
 @CapacitorPlugin(name = "CapgoWatch")
 public class CapgoWatchPlugin extends Plugin {
 
-    private final String pluginVersion = "8.0.25";
-    private static final String NOT_SUPPORTED_MSG = "Apple Watch is only supported on iOS";
+    private static final String TAG = "CapgoWatchPlugin";
+    private static final String PLUGIN_VERSION = "8.0.25";
+
+    /** Path for regular messages sent/received via MessageClient. */
+    static final String PATH_MESSAGE = "/capgo/message";
+    /** Path prefix for messages that require a reply. */
+    static final String PATH_MESSAGE_WITH_REPLY = "/capgo/message/withreply";
+    /** Path prefix for reply messages sent back to the watch. */
+    static final String PATH_REPLY = "/capgo/reply/";
+    /** DataItem path for application context sync. */
+    static final String PATH_CONTEXT = "/capgo/context";
+    /** DataItem path prefix for user info transfers. */
+    static final String PATH_USER_INFO = "/capgo/userinfo/";
+
+    /** Maps callbackId to sourceNodeId for pending reply messages. */
+    private final Map<String, String> pendingReplies = new ConcurrentHashMap<>();
+
+    /** Shared thread pool for all background Wear OS operations. */
+    private final ExecutorService executor = Executors.newCachedThreadPool();
+
+    private MessageClient messageClient;
+    private DataClient dataClient;
+
+    private final MessageClient.OnMessageReceivedListener messageListener = this::handleMessageReceived;
+    private final DataClient.OnDataChangedListener dataListener = this::handleDataChanged;
+
+    @Override
+    public void load() {
+        messageClient = Wearable.getMessageClient(getContext());
+        dataClient = Wearable.getDataClient(getContext());
+        messageClient.addListener(messageListener);
+        dataClient.addListener(dataListener);
+    }
+
+    @Override
+    protected void handleOnDestroy() {
+        if (messageClient != null) {
+            messageClient.removeListener(messageListener);
+        }
+        if (dataClient != null) {
+            dataClient.removeListener(dataListener);
+        }
+        executor.shutdown();
+    }
+
+    // ── Incoming message / data handlers ─────────────────────────────────────
+
+    private void handleMessageReceived(MessageEvent event) {
+        final String path = event.getPath();
+        final String nodeId = event.getSourceNodeId();
+        final String payload = new String(event.getData(), StandardCharsets.UTF_8);
+
+        try {
+            final JSONObject json = new JSONObject(payload);
+            final JSObject messageData = new JSObject(json.toString());
+
+            if (path != null && path.startsWith(PATH_MESSAGE_WITH_REPLY)) {
+                final String callbackId = UUID.randomUUID().toString();
+                pendingReplies.put(callbackId, nodeId);
+
+                final JSObject evt = new JSObject();
+                evt.put("message", messageData);
+                evt.put("callbackId", callbackId);
+                notifyListeners("messageReceivedWithReply", evt);
+            } else {
+                final JSObject evt = new JSObject();
+                evt.put("message", messageData);
+                notifyListeners("messageReceived", evt);
+            }
+        } catch (JSONException e) {
+            Log.e(TAG, "Error parsing received message", e);
+        }
+    }
+
+    private void handleDataChanged(DataEventBuffer dataEvents) {
+        for (DataEvent event : dataEvents) {
+            if (event.getType() == DataEvent.TYPE_CHANGED) {
+                final DataItem item = event.getDataItem();
+                final String path = item.getUri().getPath();
+                try {
+                    final DataMap dataMap = DataMapItem.fromDataItem(item).getDataMap();
+                    final String payload = dataMap.getString("payload", "{}");
+                    final JSONObject json = new JSONObject(payload);
+                    final JSObject data = new JSObject(json.toString());
+
+                    if (path != null && path.startsWith(PATH_CONTEXT)) {
+                        final JSObject evt = new JSObject();
+                        evt.put("context", data);
+                        notifyListeners("applicationContextReceived", evt);
+                    } else if (path != null && path.startsWith(PATH_USER_INFO)) {
+                        final JSObject evt = new JSObject();
+                        evt.put("userInfo", data);
+                        notifyListeners("userInfoReceived", evt);
+                    }
+                } catch (Exception e) {
+                    Log.e(TAG, "Error processing data change", e);
+                }
+            }
+        }
+    }
+
+    // ── Plugin methods ────────────────────────────────────────────────────────
 
     @PluginMethod
     public void sendMessage(final PluginCall call) {
-        call.reject(NOT_SUPPORTED_MSG);
+        final JSObject data = call.getObject("data");
+        if (data == null) {
+            call.reject("Missing required parameter: 'data'");
+            return;
+        }
+
+        final byte[] payload = data.toString().getBytes(StandardCharsets.UTF_8);
+        executor.execute(
+            () -> {
+                try {
+                    final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
+                    if (nodes.isEmpty()) {
+                        call.reject("No connected Wear OS devices found");
+                        return;
+                    }
+                    for (final Node node : nodes) {
+                        Tasks.await(messageClient.sendMessage(node.getId(), PATH_MESSAGE, payload));
+                    }
+                    call.resolve();
+                } catch (ExecutionException | InterruptedException e) {
+                    call.reject("Failed to send message: " + e.getMessage(), e);
+                }
+            }
+        );
     }
 
     @PluginMethod
     public void updateApplicationContext(final PluginCall call) {
-        call.reject(NOT_SUPPORTED_MSG);
+        final JSObject context = call.getObject("context");
+        if (context == null) {
+            call.reject("Missing required parameter: 'context'");
+            return;
+        }
+
+        executor.execute(
+            () -> {
+                try {
+                    final PutDataMapRequest request = PutDataMapRequest.create(PATH_CONTEXT);
+                    request.getDataMap().putString("payload", context.toString());
+                    request.setUrgent();
+                    Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
+                    call.resolve();
+                } catch (ExecutionException | InterruptedException e) {
+                    call.reject("Failed to update application context: " + e.getMessage(), e);
+                }
+            }
+        );
     }
 
     @PluginMethod
     public void transferUserInfo(final PluginCall call) {
-        call.reject(NOT_SUPPORTED_MSG);
+        final JSObject userInfo = call.getObject("userInfo");
+        if (userInfo == null) {
+            call.reject("Missing required parameter: 'userInfo'");
+            return;
+        }
+
+        final String path = PATH_USER_INFO + UUID.randomUUID();
+        executor.execute(
+            () -> {
+                try {
+                    final PutDataMapRequest request = PutDataMapRequest.create(path);
+                    request.getDataMap().putString("payload", userInfo.toString());
+                    request.setUrgent();
+                    Tasks.await(dataClient.putDataItem(request.asPutDataRequest()));
+                    call.resolve();
+                } catch (ExecutionException | InterruptedException e) {
+                    call.reject("Failed to transfer user info: " + e.getMessage(), e);
+                }
+            }
+        );
     }
 
     @PluginMethod
     public void replyToMessage(final PluginCall call) {
-        call.reject(NOT_SUPPORTED_MSG);
+        final String callbackId = call.getString("callbackId");
+        final JSObject data = call.getObject("data");
+
+        if (callbackId == null || callbackId.isEmpty()) {
+            call.reject("Missing required parameter: 'callbackId'");
+            return;
+        }
+        if (data == null) {
+            call.reject("Missing required parameter: 'data'");
+            return;
+        }
+
+        final String nodeId = pendingReplies.remove(callbackId);
+        if (nodeId == null) {
+            call.reject("No pending reply found for callbackId: " + callbackId);
+            return;
+        }
+
+        final byte[] payload = data.toString().getBytes(StandardCharsets.UTF_8);
+        final String replyPath = PATH_REPLY + callbackId;
+        executor.execute(
+            () -> {
+                try {
+                    Tasks.await(messageClient.sendMessage(nodeId, replyPath, payload));
+                    call.resolve();
+                } catch (ExecutionException | InterruptedException e) {
+                    call.reject("Failed to send reply: " + e.getMessage(), e);
+                }
+            }
+        );
     }
 
     @PluginMethod
     public void getInfo(final PluginCall call) {
-        final JSObject ret = new JSObject();
-        ret.put("isSupported", false);
-        ret.put("isPaired", false);
-        ret.put("isWatchAppInstalled", false);
-        ret.put("isReachable", false);
-        ret.put("activationState", 0);
-        call.resolve(ret);
+        executor.execute(
+            () -> {
+                try {
+                    final List<Node> nodes = Tasks.await(Wearable.getNodeClient(getContext()).getConnectedNodes());
+                    final boolean isReachable = !nodes.isEmpty();
+                    final JSObject ret = new JSObject();
+                    ret.put("isSupported", true);
+                    ret.put("isPaired", isReachable);
+                    ret.put("isWatchAppInstalled", isReachable);
+                    ret.put("isReachable", isReachable);
+                    ret.put("activationState", isReachable ? 2 : 0);
+                    call.resolve(ret);
+                } catch (ExecutionException | InterruptedException e) {
+                    // Wear OS API unavailable (e.g. Google Play Services missing)
+                    final JSObject ret = new JSObject();
+                    ret.put("isSupported", false);
+                    ret.put("isPaired", false);
+                    ret.put("isWatchAppInstalled", false);
+                    ret.put("isReachable", false);
+                    ret.put("activationState", 0);
+                    call.resolve(ret);
+                }
+            }
+        );
     }
 
     @PluginMethod
     public void getPluginVersion(final PluginCall call) {
-        try {
-            final JSObject ret = new JSObject();
-            ret.put("version", this.pluginVersion);
-            call.resolve(ret);
-        } catch (final Exception e) {
-            call.reject("Could not get plugin version", e);
-        }
+        final JSObject ret = new JSObject();
+        ret.put("version", PLUGIN_VERSION);
+        call.resolve(ret);
     }
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -64,22 +64,28 @@ export interface ReplyMessageOptions {
 }
 
 /**
- * Information about Watch connectivity status.
+ * Information about Watch / Wear OS connectivity status.
  *
  * @since 8.0.0
  */
 export interface WatchInfo {
   /**
-   * Whether WatchConnectivity is supported on this device.
-   * Always false on iPad, web, and Android.
+   * Whether the watch communication API is supported on this device.
+   * - iOS: false on iPad; true on iPhone when WatchConnectivity is available.
+   * - Android: true when Google Play Services with Wear OS support is available; false otherwise.
+   * - Web: always false.
    */
   isSupported: boolean;
   /**
-   * Whether an Apple Watch is paired with this iPhone.
+   * Whether a watch is currently paired/connected.
+   * - iOS: whether an Apple Watch is paired with this iPhone.
+   * - Android: whether at least one Wear OS node is currently connected.
    */
   isPaired: boolean;
   /**
-   * Whether the paired watch has the companion app installed.
+   * Whether the watch companion app is installed.
+   * - iOS: whether the paired Apple Watch has the companion app installed.
+   * - Android: whether at least one connected Wear OS node is reachable (used as a proxy).
    */
   isWatchAppInstalled: boolean;
   /**
@@ -87,8 +93,9 @@ export interface WatchInfo {
    */
   isReachable: boolean;
   /**
-   * The current activation state of the WCSession.
-   * 0 = notActivated, 1 = inactive, 2 = activated
+   * The current session activation state.
+   * - iOS: 0 = notActivated, 1 = inactive, 2 = activated (WCSessionActivationState).
+   * - Android: 2 when a Wear OS node is connected, 0 otherwise.
    */
   activationState: number;
 }
@@ -171,8 +178,12 @@ export interface ActivationStateChangedEvent {
 }
 
 /**
- * Apple Watch communication plugin for Capacitor.
- * Provides bidirectional messaging between iPhone and Apple Watch using WatchConnectivity.
+ * Watch / Wear OS communication plugin for Capacitor.
+ * Provides bidirectional messaging between the phone and a paired watch.
+ *
+ * - **iOS**: uses Apple WatchConnectivity framework to communicate with Apple Watch.
+ * - **Android**: uses Google Wear OS Data Layer API (play-services-wearable) to communicate with a Wear OS watch.
+ * - **Web**: not supported; all methods throw or return safe defaults.
  *
  * @since 8.0.0
  */


### PR DESCRIPTION
Closes #3

## Summary
- Implement full Android Wear OS support in `capacitor-watch` using Google Play Services Wearable Data Layer API (`play-services-wearable`)
- Mirror the existing JS API: `sendMessage`, `updateApplicationContext`, `transferUserInfo`, `replyToMessage`, `getInfo`, and event listeners (`messageReceived`, `messageReceivedWithReply`, `applicationContextReceived`, `userInfoReceived`)
- Update TypeScript definitions and generated docs to document iOS (WatchConnectivity) and Android (Wear OS) behavior

## Test plan
- [x] `bun run verify:android` — Gradle build, lint, and tests pass
- [x] `bun run verify:web` — docgen, TypeScript, and rollup build pass
- [ ] CI `test.yml` passes (iOS + Android + web)
- [ ] Manual test with paired Wear OS device: `getInfo()`, send/receive messages, context sync


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android Wear OS support for sending messages, syncing data, and receiving replies.
  * Expanded device status reporting with clearer support, pairing, reachability, and app-installed details across iOS and Android.
  * Updated documentation to reflect Watch / Wear OS compatibility and Web behavior.

* **Bug Fixes**
  * Improved error handling when a connected watch isn’t available or a reply can’t be matched.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->